### PR TITLE
Revert "Bump to version 1.0.4"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.0.4" %}
-{% set sha256 = "bb27692cca7bce5b092ca02a6b0de82144c459399c2774021cd63c19834e81de" %}
+{% set version = "1.0.3" %}
+{% set sha256 = "72f398cdd87e74b2670ebfa80a34d23e3adeae08ff027282cfd09cfd58b4c0d7" %}
 
 package:
   name: qgrid


### PR DESCRIPTION
Reverts conda-forge/qgrid-feedstock#8....I accidentally merged it before the build was done running and now the build seems to be failing.